### PR TITLE
fix(torch): processing duplications

### DIFF
--- a/pkg/k8s/statefulsets.go
+++ b/pkg/k8s/statefulsets.go
@@ -45,17 +45,13 @@ func WatchStatefulSets() error {
 
 	// Watch for events on the watcher channel
 	for event := range watcher.ResultChan() {
-		// Check if the event object is of type *v1.StatefulSet
 		if statefulSet, ok := event.Object.(*v1.StatefulSet); ok {
 			if !ok {
-				// If it's not a StatefulSet, log a warning and continue with the next event.
 				log.Warn("Received an event that is not a StatefulSet. Skipping this resource...")
 				continue
 			}
 
-			// Check if the StatefulSet is valid based on the conditions
 			if isStatefulSetValid(statefulSet) {
-				// Perform necessary actions, such as adding the node to the Redis queue
 				err := redis.Producer(statefulSet.Name, queueK8SNodes)
 				if err != nil {
 					log.Error("ERROR adding the node to the queue: ", err)


### PR DESCRIPTION
hello team!

small one, it fixes to add duplicates to the queue, that happened because the watcher sends an event for every container in the pod, but we only need it once.

cheers! 🚀 

closes: https://github.com/celestiaorg/devops/issues/577

cc: @celestiaorg/devops 